### PR TITLE
Incrementer & Tests

### DIFF
--- a/cypress/e2e/App.spec.cy.ts
+++ b/cypress/e2e/App.spec.cy.ts
@@ -10,10 +10,11 @@ describe('Stardew Friends User Stories', () => {
         statusCode: 200,
         fixture: 'character'
       }).as('getCharacter')
+    .visit('http://localhost:3000/')
   })
   it('Displays Homepage', () => {
-    cy.visit('http://localhost:3000/')
-    .get('.loading-screen').contains('h2', 'Loading...')
+    // cy.visit('http://localhost:3000/')
+    cy.get('.loading-screen').contains('h2', 'Loading...')
     .get('.loading-image').should('have.attr', 'src')/*.should('include', 'data:image/gif')*/
     .wait('@getCharacters')
     .get('.nav-bar').children().should('have.length', 3)
@@ -27,19 +28,48 @@ describe('Stardew Friends User Stories', () => {
     .get('.card-wrapper').last().contains('p', 'Wizard')
     .get('.char-avatar').last().should('have.attr', 'alt').should('equal', 'Wizard avatar')
   })
-  // it('Shows individual character profile', () => {
-  //   //click character from homepage
-  //   //check content
-  // })
-  // it('Adds and removes besties', () => {
-  //   //add bestie from character profile
-  //   //check besties view
-  //   //remove bestie
-  //   //check bestie view
-  // })
-  // it('Increments frienship level', () => {
-
-  // })
+  it('Shows individual character profile', () => {
+    // cy.visit('http://localhost:3000/')
+    cy.get('.card-wrapper').last().click()
+    .get('.nav-bar').children().should('have.length', 2)
+    .get('.hero-wrapper').contains('h2', 'Wizard')
+    .get('.profile-avatar').should('have.attr', 'alt').should('equal', 'Wizard avatar')
+    .get('.bestie-button').should('exist')
+    .get('.profile-details').children().should('have.length', 6)
+    .get('.profile-details').contains('h3', 'Birthday')
+    .get('.birthday').contains('p', 'Winter 17')
+    .get('.profile-details').contains('h3', 'Hobbies')
+    .get('.hobby').first().contains('p', 'alchemy')
+    .get('.hobby').last().contains('p', 'divination')
+    .get('.profile-details').contains('h3', 'Loved Gifts')
+    .get('.gift').first().contains('p', 'Book of Mysteries')
+    .get('.gift').last().contains('p', 'Void Essence')
+  })
+  it('Adds, increments, and removes besties', () => {
+    cy.get('.card-wrapper').last().click()
+    .get('.bestie-button').click()
+    .get('.remove-button').should('exist')
+    .get('#besties-link').click()
+    // .get('#besties-link').contains('1')
+    .get('.bestie-count').contains('You have 1 bestie!')
+    .get('.bestie-avatar').should('have.attr', 'alt').should('equal', 'Wizard avatar')
+    .get('.name').contains('Wizard')
+    .get('.profile-link').contains('View Profile')
+    .get('.friendship-label').contains('Friendship Level')
+    .get('.incrementer').children().should('have.length', 3)
+    .get('.incrementer').contains('p', '0')
+    .get('#up').click().click()
+    .get('.incrementer').contains('p', '2')
+    .get('#down').click()
+    .get('.incrementer').contains('p', '1')
+    //remove bestie
+    //check bestie view
+    .get('.profile-link').click()
+    .get('.remove-button').click()
+    .get('.bestie-button').should('exist')
+    .get('#besties-link').click()
+    .get('.bestie-count').contains('You don\'t have any besties :(')
+  })
 
   // it('Displays search results', () => {
   //   //check value of search input

--- a/cypress/e2e/App.spec.cy.ts
+++ b/cypress/e2e/App.spec.cy.ts
@@ -16,6 +16,7 @@ describe('Stardew Friends User Stories', () => {
   it('Displays Homepage', () => {
     cy.get('.loading-screen').contains('h2', 'Loading...')
     .url().should('eq', 'http://localhost:3000/')
+    .get('.loading-screen').should('be.visible')
     .get('.loading-image').should('have.attr', 'src')/*.should('include', 'data:image/gif')*/
     .wait('@getCharacters')
     .get('.nav-bar').children().should('have.length', 3)

--- a/cypress/e2e/App.spec.cy.ts
+++ b/cypress/e2e/App.spec.cy.ts
@@ -13,7 +13,6 @@ describe('Stardew Friends User Stories', () => {
     .visit('http://localhost:3000/')
   })
   it('Displays Homepage', () => {
-    // cy.visit('http://localhost:3000/')
     cy.get('.loading-screen').contains('h2', 'Loading...')
     .get('.loading-image').should('have.attr', 'src')/*.should('include', 'data:image/gif')*/
     .wait('@getCharacters')
@@ -29,7 +28,6 @@ describe('Stardew Friends User Stories', () => {
     .get('.char-avatar').last().should('have.attr', 'alt').should('equal', 'Wizard avatar')
   })
   it('Shows individual character profile', () => {
-    // cy.visit('http://localhost:3000/')
     cy.get('.card-wrapper').last().click()
     .get('.nav-bar').children().should('have.length', 2)
     .get('.hero-wrapper').contains('h2', 'Wizard')
@@ -62,8 +60,6 @@ describe('Stardew Friends User Stories', () => {
     .get('.incrementer').contains('p', '2')
     .get('#down').click()
     .get('.incrementer').contains('p', '1')
-    //remove bestie
-    //check bestie view
     .get('.profile-link').click()
     .get('.remove-button').click()
     .get('.bestie-button').should('exist')
@@ -71,10 +67,12 @@ describe('Stardew Friends User Stories', () => {
     .get('.bestie-count').contains('You don\'t have any besties :(')
   })
 
-  // it('Displays search results', () => {
-  //   //check value of search input
-  //   //type search
-  //   //check displayed results
-
-  // })
+  it('Displays search results', () => {
+    cy.get('.search-bar').type('wi').should('have.value', 'wi')
+    .get('.character-cards').children().should('have.length', 2)
+    .get('.card-wrapper').first().contains('p', 'Willy')
+    .get('.char-avatar').first().should('have.attr', 'alt').should('equal', 'Willy avatar')
+    .get('.card-wrapper').last().contains('p', 'Wizard')
+    .get('.char-avatar').last().should('have.attr', 'alt').should('equal', 'Wizard avatar')
+  })
 })

--- a/cypress/e2e/App.spec.cy.ts
+++ b/cypress/e2e/App.spec.cy.ts
@@ -12,25 +12,39 @@ describe('Stardew Friends User Stories', () => {
       }).as('getCharacter')
   })
   it('Displays Homepage', () => {
-    cy.visit('https://stardew-friends.vercel.app/')
+    cy.visit('http://localhost:3000/')
+    .get('.loading-screen').contains('h2', 'Loading...')
+    .get('.loading-image').should('have.attr', 'src')/*.should('include', 'data:image/gif')*/
     .wait('@getCharacters')
-    //check loaded content
+    .get('.nav-bar').children().should('have.length', 3)
+    .get('.heading').contains('Stardew Friends')
+    .get('.links').contains('a', 'Home')
+    .get('.links').contains('a', 'Besties')
+    .get('.search-bar').should('exist')
+    .get('.character-cards').children().should('have.length', 4)
+    .get('.card-wrapper').first().contains('p', 'Sandy')
+    .get('.char-avatar').first().should('have.attr', 'alt').should('equal', 'Sandy avatar')
+    .get('.card-wrapper').last().contains('p', 'Wizard')
+    .get('.char-avatar').last().should('have.attr', 'alt').should('equal', 'Wizard avatar')
   })
-  it('Shows individual character profile', () => {
-    //click character from homepage
-    //check content
-  })
-  it('Adds and removes besties', () => {
-    //add bestie from character profile
-    //check besties view
-    //remove bestie
-    //check bestie view
+  // it('Shows individual character profile', () => {
+  //   //click character from homepage
+  //   //check content
+  // })
+  // it('Adds and removes besties', () => {
+  //   //add bestie from character profile
+  //   //check besties view
+  //   //remove bestie
+  //   //check bestie view
+  // })
+  // it('Increments frienship level', () => {
 
-  })
-  it('Displays search results', () => {
-    //check value of search input
-    //type search
-    //check displayed results
+  // })
 
-  })
+  // it('Displays search results', () => {
+  //   //check value of search input
+  //   //type search
+  //   //check displayed results
+
+  // })
 })

--- a/cypress/e2e/App.spec.cy.ts
+++ b/cypress/e2e/App.spec.cy.ts
@@ -11,6 +11,7 @@ describe('Stardew Friends User Stories', () => {
         fixture: 'character'
       }).as('getCharacter')
     .visit('http://localhost:3000/')
+    //set viewport size if needed after css refactor
   })
   it('Displays Homepage', () => {
     cy.get('.loading-screen').contains('h2', 'Loading...')

--- a/cypress/e2e/App.spec.cy.ts
+++ b/cypress/e2e/App.spec.cy.ts
@@ -15,13 +15,14 @@ describe('Stardew Friends User Stories', () => {
   })
   it('Displays Homepage', () => {
     cy.get('.loading-screen').contains('h2', 'Loading...')
+    .url().should('eq', 'http://localhost:3000/')
     .get('.loading-image').should('have.attr', 'src')/*.should('include', 'data:image/gif')*/
     .wait('@getCharacters')
     .get('.nav-bar').children().should('have.length', 3)
     .get('.heading').contains('Stardew Friends')
     .get('.links').contains('a', 'Home')
     .get('.links').contains('a', 'Besties')
-    .get('.search-bar').should('exist')
+    .get('.search-bar').should('have.attr', 'placeholder').should('eq', 'Search')
     .get('.character-cards').children().should('have.length', 4)
     .get('.card-wrapper').first().contains('p', 'Sandy')
     .get('.char-avatar').first().should('have.attr', 'alt').should('equal', 'Sandy avatar')
@@ -30,6 +31,7 @@ describe('Stardew Friends User Stories', () => {
   })
   it('Shows individual character profile', () => {
     cy.get('.card-wrapper').last().click()
+    .url().should('eq', 'http://localhost:3000/characters/34')
     .get('.nav-bar').children().should('have.length', 2)
     .get('.hero-wrapper').contains('h2', 'Wizard')
     .get('.profile-avatar').should('have.attr', 'alt').should('equal', 'Wizard avatar')
@@ -50,6 +52,7 @@ describe('Stardew Friends User Stories', () => {
     .get('.remove-button').should('exist')
     .get('#besties-link').click()
     // .get('#besties-link').contains('1')
+    .url().should('eq', 'http://localhost:3000/besties')
     .get('.bestie-count').contains('You have 1 bestie!')
     .get('.bestie-avatar').should('have.attr', 'alt').should('equal', 'Wizard avatar')
     .get('.name').contains('Wizard')

--- a/cypress/e2e/App.spec.cy.ts
+++ b/cypress/e2e/App.spec.cy.ts
@@ -16,4 +16,21 @@ describe('Stardew Friends User Stories', () => {
     .wait('@getCharacters')
     //check loaded content
   })
+  it('Shows individual character profile', () => {
+    //click character from homepage
+    //check content
+  })
+  it('Adds and removes besties', () => {
+    //add bestie from character profile
+    //check besties view
+    //remove bestie
+    //check bestie view
+
+  })
+  it('Displays search results', () => {
+    //check value of search input
+    //type search
+    //check displayed results
+
+  })
 })

--- a/cypress/e2e/App.spec.cy.ts
+++ b/cypress/e2e/App.spec.cy.ts
@@ -5,6 +5,11 @@ describe('Stardew Friends User Stories', () => {
         statusCode: 200,
         fixture: 'characters'
       }).as('getCharacters')
+    cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters/34',
+      {
+        statusCode: 200,
+        fixture: 'character'
+      }).as('getCharacter')
   })
   it('Displays Homepage', () => {
     cy.visit('https://stardew-friends.vercel.app/')

--- a/cypress/e2e/Errors.spec.cy.ts
+++ b/cypress/e2e/Errors.spec.cy.ts
@@ -1,45 +1,32 @@
 describe('Stardew Friends Error Handling', () => {
-    beforeEach(() => {
-        // // cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters',
-        // //   {
-        // //     statusCode: 500,
-        // //   }).as('getCharacters')
-        // cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters/34',
-        //   {
-        //     statusCode: 500,
-        //   }).as('getCharacter')
-        //   .visit('https://stardew-friends.vercel.app/')
-      })
-      it('Displays error message if server is down', () => {
-        cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters',
-          {
-            statusCode: 500,
-          }).as('getCharacters')
-        cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters/34',
-          {
-            statusCode: 500,
-          }).as('getCharacter')
-        .visit('http://localhost:3000/')
-        //should i replace these urls with deployed link again once suite completed?
-        .get('.error-message').contains('Error: We couldn\'t get the characters - 500')
-        
-        // .visit('http://localhost:3000/characters/34')
-        //test profile content
+    it('Displays error message if server is down', () => {
+      cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters',
+        {
+          statusCode: 500,
+        }).as('getCharacters')
+      cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters/34',
+        {
+          statusCode: 500,
+        }).as('getCharacter')
+      .visit('http://localhost:3000/')
+      //should i replace these urls with deployed link again once suite completed?
+      .get('.error-message').contains('Error: We couldn\'t get the characters - 500')
+      .visit('http://localhost:3000/characters/34')
+      .get('.error-message').contains('Error: We couldn\'t get that character - 500')
+    })
 
-      })
-      it('Displays page not found message if bad path visited', () => {
-        // cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters',
-        //   {
-        //     statusCode: 404,
-        //   })
-          cy.visit('http://localhost:3000//badpath')
-        //test content
-        // cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters/badpath',
-        //   {
-        //     statusCode: 404,
-        //   })
-        // cy.visit('https://stardew-friends.vercel.app/characters/badpath')
-        //test content
-
-      })
+    it('Displays page not found message if bad path visited', () => {
+      cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters',
+        {
+          statusCode: 404,
+        }).as('badGetCharacters')
+      cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters/badpath',
+      {
+        statusCode: 404,
+      }).as('badGetCharacter')
+      .visit('http://localhost:3000/badpath')
+      .get('.error-message').contains('That page doesn\'t exist')
+      .visit('http://localhost:3000/characters/badpath')
+      .get('.error-message').contains('Error: We couldn\'t get that character - 404')
+    })
 })

--- a/cypress/e2e/Errors.spec.cy.ts
+++ b/cypress/e2e/Errors.spec.cy.ts
@@ -25,7 +25,8 @@ describe('Stardew Friends Error Handling', () => {
         statusCode: 404,
       }).as('badGetCharacter')
       .visit('http://localhost:3000/badpath')
-      .get('.error-message').contains('That page doesn\'t exist')
+      // .wait('@badGetCharacters')
+      .get('.error-message').contains('That page doesn\'t exist') //why is this test blinking?
       .visit('http://localhost:3000/characters/badpath')
       .get('.error-message').contains('Error: We couldn\'t get that character - 404')
     })

--- a/cypress/e2e/Errors.spec.cy.ts
+++ b/cypress/e2e/Errors.spec.cy.ts
@@ -1,5 +1,34 @@
 describe('Stardew Friends Error Handling', () => {
-    it('passes', () => {
-        cy.visit('https://example.cypress.io')
+    beforeEach(() => {
+        cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters',
+          {
+            statusCode: 500,
+          }).as('getCharacters')
+        cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters/34',
+          {
+            statusCode: 500,
+          }).as('getCharacter')
+          .visit('https://stardew-friends.vercel.app/')
+      })
+      it('Displays error message if server is down', () => {
+        //test home page content
+        cy.visit('https://stardew-friends.vercel.app/characters/34')
+        //test profile content
+
+      })
+      it('Displays page not found message if bad path visited', () => {
+        cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters',
+          {
+            statusCode: 404,
+          })
+          cy.visit('https://stardew-friends.vercel.app/badpath')
+        //test content
+        cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters/badpath',
+          {
+            statusCode: 404,
+          })
+        cy.visit('https://stardew-friends.vercel.app/characters/badpath')
+        //test content
+
       })
 })

--- a/cypress/e2e/Errors.spec.cy.ts
+++ b/cypress/e2e/Errors.spec.cy.ts
@@ -18,15 +18,14 @@ describe('Stardew Friends Error Handling', () => {
     it('Displays page not found message if bad path visited', () => {
       cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters',
         {
-          statusCode: 404,
+          statusCode: 200,
+          fixture: 'characters'
         }).as('badGetCharacters')
       cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters/badpath',
       {
         statusCode: 404,
       }).as('badGetCharacter')
       .visit('http://localhost:3000/badpath')
-      // .wait('@badGetCharacters')
-      //check url
       .get('.error-message').contains('That page doesn\'t exist') //why is this test blinking?
       .visit('http://localhost:3000/characters/badpath')
       .get('.error-message').contains('Error: We couldn\'t get that character - 404')

--- a/cypress/e2e/Errors.spec.cy.ts
+++ b/cypress/e2e/Errors.spec.cy.ts
@@ -20,9 +20,10 @@ describe('Stardew Friends Error Handling', () => {
             statusCode: 500,
           }).as('getCharacter')
         .visit('http://localhost:3000/')
-        //test home page content
+        //should i replace these urls with deployed link again once suite completed?
+        .get('.error-message').contains('Error: We couldn\'t get the characters - 500')
         
-        .visit('http://localhost:3000/characters/34')
+        // .visit('http://localhost:3000/characters/34')
         //test profile content
 
       })

--- a/cypress/e2e/Errors.spec.cy.ts
+++ b/cypress/e2e/Errors.spec.cy.ts
@@ -26,6 +26,7 @@ describe('Stardew Friends Error Handling', () => {
       }).as('badGetCharacter')
       .visit('http://localhost:3000/badpath')
       // .wait('@badGetCharacters')
+      //check url
       .get('.error-message').contains('That page doesn\'t exist') //why is this test blinking?
       .visit('http://localhost:3000/characters/badpath')
       .get('.error-message').contains('Error: We couldn\'t get that character - 404')

--- a/cypress/e2e/Errors.spec.cy.ts
+++ b/cypress/e2e/Errors.spec.cy.ts
@@ -1,5 +1,16 @@
 describe('Stardew Friends Error Handling', () => {
     beforeEach(() => {
+        // // cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters',
+        // //   {
+        // //     statusCode: 500,
+        // //   }).as('getCharacters')
+        // cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters/34',
+        //   {
+        //     statusCode: 500,
+        //   }).as('getCharacter')
+        //   .visit('https://stardew-friends.vercel.app/')
+      })
+      it('Displays error message if server is down', () => {
         cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters',
           {
             statusCode: 500,
@@ -8,26 +19,25 @@ describe('Stardew Friends Error Handling', () => {
           {
             statusCode: 500,
           }).as('getCharacter')
-          .visit('https://stardew-friends.vercel.app/')
-      })
-      it('Displays error message if server is down', () => {
+        .visit('http://localhost:3000/')
         //test home page content
-        cy.visit('https://stardew-friends.vercel.app/characters/34')
+        
+        .visit('http://localhost:3000/characters/34')
         //test profile content
 
       })
       it('Displays page not found message if bad path visited', () => {
-        cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters',
-          {
-            statusCode: 404,
-          })
-          cy.visit('https://stardew-friends.vercel.app/badpath')
+        // cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters',
+        //   {
+        //     statusCode: 404,
+        //   })
+          cy.visit('http://localhost:3000//badpath')
         //test content
-        cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters/badpath',
-          {
-            statusCode: 404,
-          })
-        cy.visit('https://stardew-friends.vercel.app/characters/badpath')
+        // cy.intercept('GET', 'https://stardew-api.onrender.com/api/v1/characters/badpath',
+        //   {
+        //     statusCode: 404,
+        //   })
+        // cy.visit('https://stardew-friends.vercel.app/characters/badpath')
         //test content
 
       })

--- a/cypress/fixtures/character.json
+++ b/cypress/fixtures/character.json
@@ -1,0 +1,13 @@
+{
+    "id": "34",
+    "name": "Wizard",
+    "birthday": "'Winter 17'",
+    "hobbies": [
+      "alchemy",
+      "potion brewing",
+      "divination"
+    ],
+    "avatar": "https://stardewvalleywiki.com/mediawiki/images/c/c7/Wizard.png",
+    "favGifts": ["'Book of Mysteries'", "'Purple Mushroom'", "'Solar Essence'", "'Super Cucumber'", "'Void Essence'"
+    ]
+  }

--- a/cypress/fixtures/character.json
+++ b/cypress/fixtures/character.json
@@ -8,6 +8,6 @@
       "divination"
     ],
     "avatar": "https://stardewvalleywiki.com/mediawiki/images/c/c7/Wizard.png",
-    "favGifts": ["'Book of Mysteries'", "'Purple Mushroom'", "'Solar Essence'", "'Super Cucumber'", "'Void Essence'"
+    "favGifts": ["Book of Mysteries", "Purple Mushroom", "Solar Essence", "Super Cucumber", "Void Essence"
     ]
   }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -41,7 +41,7 @@ function App() {
   useEffect(() => {
     fetchCharacters();
     // @ts-expect-error
-    const storedBesties= JSON.parse(sessionStorage.getItem('besties'))
+    const storedBesties= JSON.parse(localStorage.getItem('besties'))
     if (!storedBesties) {
       setBesties([])
     } else {
@@ -70,9 +70,9 @@ function App() {
     if (besties.length) {
       const isBestie = besties.find(bestie => newBestie.id === bestie.id);
       if (!isBestie) {
-        sessionStorage.setItem('besties', JSON.stringify([...besties, newBestie]));
+        localStorage.setItem('besties', JSON.stringify([...besties, newBestie]));
         // @ts-expect-error
-        const storedBesties= JSON.parse(sessionStorage.getItem('besties'))
+        const storedBesties= JSON.parse(localStorage.getItem('besties'))
         setBesties(storedBesties)
       } else if(isBestie) {
         const name = isBestie.name
@@ -80,18 +80,18 @@ function App() {
         //refactor with a modal and useRef hook if notification still needed
       }
     } else {
-      sessionStorage.setItem('besties', JSON.stringify([...besties, newBestie]));
+      localStorage.setItem('besties', JSON.stringify([...besties, newBestie]));
         // @ts-expect-error
-        const storedBesties= JSON.parse(sessionStorage.getItem('besties'))
+        const storedBesties= JSON.parse(localStorage.getItem('besties'))
         setBesties(storedBesties)
     }
   }
 
   const removeBestie = (id: string) => {
     const newBesties = besties.filter(bestie => bestie.id !== id);
-    sessionStorage.setItem('besties', JSON.stringify(newBesties));
+    localStorage.setItem('besties', JSON.stringify(newBesties));
     // @ts-expect-error
-    const storedBesties= JSON.parse(sessionStorage.getItem('besties'));
+    const storedBesties= JSON.parse(localStorage.getItem('besties'));
     setBesties(storedBesties)
   }
 

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -62,6 +62,7 @@ function App() {
       setLoading(false);
     } catch(error) {
         setError(`${error}`)
+        setLoading(false);
     }
   }
 

--- a/src/components/BestieCard/BestieCard.css
+++ b/src/components/BestieCard/BestieCard.css
@@ -4,7 +4,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 8px;
+    padding: 10px 20px;
     margin: 15px;
     background: var(--sec-acc-color);
     border: var(--border-style);
@@ -17,4 +17,9 @@
     & a:hover, a:focus {
         color: var(--sec-text-color);
     }
+}
+
+.profile-link {
+    margin: 0;
+    margin-top: 8px;
 }

--- a/src/components/BestieCard/BestieCard.tsx
+++ b/src/components/BestieCard/BestieCard.tsx
@@ -15,7 +15,7 @@ interface Props {
 function BestieCard({ id, name, avatar, friendship, besties, setBesties }: Props) {
     return (
         <section className='bestie-card'>
-            <img src={avatar}/>
+            <img className='bestie-avatar'src={avatar} alt={`${name} avatar`}/>
             <p className='name'>{name}</p>
             <Link to={`/characters/${id}`}>
                 <p className='profile-link'>View Profile</p>

--- a/src/components/BestieCard/BestieCard.tsx
+++ b/src/components/BestieCard/BestieCard.tsx
@@ -18,7 +18,7 @@ function BestieCard({ id, name, avatar, friendship, besties, setBesties }: Props
             <img src={avatar}/>
             <p className='name'>{name}</p>
             <Link to={`/characters/${id}`}>
-                <p>View Profile</p>
+                <p className='profile-link'>View Profile</p>
             </Link>
             {/* <p>{`Friendship level: ${friendship}`}</p> */}
             <Incrementer friendship={friendship} id={id} besties={besties} setBesties={setBesties}/>

--- a/src/components/BestieCard/BestieCard.tsx
+++ b/src/components/BestieCard/BestieCard.tsx
@@ -21,7 +21,7 @@ function BestieCard({ id, name, avatar, friendship, besties, setBesties }: Props
                 <p>View Profile</p>
             </Link>
             {/* <p>{`Friendship level: ${friendship}`}</p> */}
-            {/* <Incrementer friendship={friendship} id={id} besties={besties} setBesties={setBesties}/> */}
+            <Incrementer friendship={friendship} id={id} besties={besties} setBesties={setBesties}/>
         </section>
     )
 }

--- a/src/components/Besties/Besties.css
+++ b/src/components/Besties/Besties.css
@@ -12,6 +12,7 @@
 
 .besties {
     display: flex;
+    /* justify-content: space-evenly; */
     justify-content: space-around;
     flex-wrap: wrap;
     padding:30px 0;

--- a/src/components/Error/Error.css
+++ b/src/components/Error/Error.css
@@ -1,0 +1,10 @@
+.error-message {
+    margin: 60px auto;
+    text-align: center;
+    padding: 50px;
+    width: 70%;
+    font-size: 2rem;
+    background: var(--sec-acc-color);
+    border: var(--border-style);
+    filter: var(--sec-drop-shadow);
+}

--- a/src/components/Error/Error.tsx
+++ b/src/components/Error/Error.tsx
@@ -5,9 +5,9 @@ interface Props {
 }
 function Error({error}: Props) {
     return (
-        <>
-            {error.length ? <h2>{error}</h2> : <h2>That page doesn't exist!</h2>}
-        </>
+        <section className='error-display'>
+            {error.length ? <h2 className='error-message'>{error}</h2> : <h2 className='error-message'>That page doesn't exist!</h2>}
+        </section>
     )
 
 }

--- a/src/components/Home/Home.css
+++ b/src/components/Home/Home.css
@@ -20,6 +20,7 @@ a {
 
 .loading-screen {
     text-align: center;
+    margin-top: 30px;
     & .loading-message {
         font-weight: 300;
         color: var(--sec-bg-color)

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -12,8 +12,6 @@ interface Props {
     error: string
     loading: boolean
     filteredChars: Char[]
-    // search: string
-    // setSearch: (query: string) => void
 }
 
 function Home({ characters, filteredChars, error, loading }: Props) {

--- a/src/components/Incrementer/Incrementer.css
+++ b/src/components/Incrementer/Incrementer.css
@@ -1,0 +1,26 @@
+.incrementer {
+    background: var(--main-acc-color);
+    color: var(--sec-text-color);
+    border: var(--border-style);
+    filter: drop-shadow(5px 5px #243763);
+    margin-top: 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 80%;
+    height: 40px;
+    & button {
+        background: none;
+        border: none;
+        color: var(--main-text-color)
+    }
+    & button:hover {
+        cursor: pointer;
+        transform: scale(1.1);
+    }
+}
+
+.friendship-label {
+    margin: 5px 0;
+    margin-top: 8px;
+}

--- a/src/components/Incrementer/Incrementer.css
+++ b/src/components/Incrementer/Incrementer.css
@@ -16,7 +16,7 @@
     }
     & button:hover {
         cursor: pointer;
-        transform: scale(1.1);
+        transform: scale(1.2);
     }
 }
 

--- a/src/components/Incrementer/Incrementer.tsx
+++ b/src/components/Incrementer/Incrementer.tsx
@@ -28,10 +28,10 @@ function Incrementer({ friendship, id, besties, setBesties }: Props) {
                 bestie.friendship = newLevel
             }
         // console.log(currentBesties);
-        sessionStorage.clear();
-        sessionStorage.setItem('besties', JSON.stringify(currentBesties));
+        localStorage.clear();
+        localStorage.setItem('besties', JSON.stringify(currentBesties));
         // @ts-expect-error
-        const storedBesties= JSON.parse(sessionStorage.getItem('besties'))
+        const storedBesties= JSON.parse(localStorage.getItem('besties'))
         setBesties(storedBesties)
         })
     }

--- a/src/components/Incrementer/Incrementer.tsx
+++ b/src/components/Incrementer/Incrementer.tsx
@@ -15,11 +15,29 @@ function Incrementer({ friendship, id, besties, setBesties }: Props) {
     function updateBestie(id: string, direction: string) {
         //set storage with current besties and bestie with updated friendship property value
         //get updated besties and setBesties
+        let newLevel = 0
         if (direction === 'up') {
-            setFriendshipLevel(friendshipLevel + 1)
+            newLevel = friendshipLevel + 1
+            // setFriendshipLevel(newLevel)
         } else if (direction === 'down') {
-            setFriendshipLevel(friendshipLevel - 1)
+            newLevel = friendshipLevel - 1
+            // setFriendshipLevel(newLevel)
         }
+        setFriendshipLevel(newLevel)
+
+        let currentBesties = [...besties];
+        currentBesties.forEach(bestie => {
+            if (bestie.id === id) {
+                bestie.friendship = newLevel
+            }
+            console.log(currentBesties)
+        // sessionStorage.clear()
+        // sessionStorage.setItem('besties', JSON.stringify([...besties, bestie]));
+        // // @ts-expect-error
+        // const storedBesties= JSON.parse(sessionStorage.getItem('besties'))
+        // setBesties(storedBesties)
+        })
+
 
         //get and store besties from local storage
         //clear storage

--- a/src/components/Incrementer/Incrementer.tsx
+++ b/src/components/Incrementer/Incrementer.tsx
@@ -30,12 +30,12 @@ function Incrementer({ friendship, id, besties, setBesties }: Props) {
             if (bestie.id === id) {
                 bestie.friendship = newLevel
             }
-            console.log(currentBesties)
-        // sessionStorage.clear()
-        // sessionStorage.setItem('besties', JSON.stringify([...besties, bestie]));
-        // // @ts-expect-error
-        // const storedBesties= JSON.parse(sessionStorage.getItem('besties'))
-        // setBesties(storedBesties)
+        console.log(currentBesties);
+        sessionStorage.clear();
+        sessionStorage.setItem('besties', JSON.stringify(currentBesties));
+        // @ts-expect-error
+        const storedBesties= JSON.parse(sessionStorage.getItem('besties'))
+        setBesties(storedBesties)
         })
 
 

--- a/src/components/Incrementer/Incrementer.tsx
+++ b/src/components/Incrementer/Incrementer.tsx
@@ -44,10 +44,10 @@ function Incrementer({ friendship, id, besties, setBesties }: Props) {
         <>
             <p className='friendship-label'>Friendship Level</p>
             <section className='incrementer'>
-                <button id='up' value='up' onClick={() => handleClick(id, 'up')}><ChevronUp /></button>
+                <button id='down' value='down' onClick={() => handleClick(id, 'down')}><ChevronDown/></button>
                 <p>{friendshipLevel}</p>
                 {/* how should I restrict this to a range? Should I make it a number input instead? */}
-                <button id='down' value='down' onClick={() => handleClick(id, 'down')}><ChevronDown/></button>
+                <button id='up' value='up' onClick={() => handleClick(id, 'up')}><ChevronUp /></button>
             </section>
         </>
     )

--- a/src/components/Incrementer/Incrementer.tsx
+++ b/src/components/Incrementer/Incrementer.tsx
@@ -1,6 +1,7 @@
 import '../Incrementer/Incrementer.css';
 import { useState } from 'react';
 import type { Friend } from '../App/App';
+import { ChevronDown, ChevronUp } from 'react-feather';
 
 interface Props {
     friendship: number
@@ -11,17 +12,13 @@ interface Props {
 
 function Incrementer({ friendship, id, besties, setBesties }: Props) {
     const [friendshipLevel, setFriendshipLevel] = useState(friendship)
-    //add function to update friendship property of friend so friendship level persists
+
     function updateBestie(id: string, direction: string) {
-        //set storage with current besties and bestie with updated friendship property value
-        //get updated besties and setBesties
         let newLevel = 0
         if (direction === 'up') {
             newLevel = friendshipLevel + 1
-            // setFriendshipLevel(newLevel)
         } else if (direction === 'down') {
             newLevel = friendshipLevel - 1
-            // setFriendshipLevel(newLevel)
         }
         setFriendshipLevel(newLevel)
 
@@ -30,47 +27,30 @@ function Incrementer({ friendship, id, besties, setBesties }: Props) {
             if (bestie.id === id) {
                 bestie.friendship = newLevel
             }
-        console.log(currentBesties);
+        // console.log(currentBesties);
         sessionStorage.clear();
         sessionStorage.setItem('besties', JSON.stringify(currentBesties));
         // @ts-expect-error
         const storedBesties= JSON.parse(sessionStorage.getItem('besties'))
         setBesties(storedBesties)
         })
-
-
-        //get and store besties from local storage
-        //clear storage
-        //find and update friendship value of respective friend object
-            //use for each and if the object matches, update friendship property with friendshipLevel
-        //set storage with updated array
-        //get newly stored besties
-        //setBesties with newly stored besties
-
-    
-        // const bestie = besties.find(bestie => bestie.id === id)
-        // // @ts-expect-error
-        // bestie.friendship = friendshipLevel
-        // sessionStorage.clear()
-        // sessionStorage.setItem('besties', JSON.stringify([...besties, bestie]));
-        // // @ts-expect-error
-        // const storedBesties= JSON.parse(sessionStorage.getItem('besties'))
-        // setBesties(storedBesties)
-        // console.log({storedBesties})
     }
 
-    function handleClick(id: string, e: any/*update to event Type*/) {
-        const direction = e.target.id;
+    function handleClick(id: string, e: any/*update to event Type*/, direction: string) {
+        // const direction = e.target.id;
         updateBestie(id, direction)
     }
 
     return (
-        <section className='incrementer'>
-            <button id='up' value='up' onClick={(e) => handleClick(id, e)}>+1</button>
-            <p>{friendshipLevel}</p>
-            {/* how should I restrict this to a range? Should I make it a number input instead? */}
-            <button id='down' value='down' onClick={(e) => handleClick(id, e)}>-1</button>
-        </section>
+        <>
+            <p className='friendship-label'>Friendship Level</p>
+            <section className='incrementer'>
+                <button id='up' value='up' onClick={(e) => handleClick(id, e, 'up')}><ChevronUp /></button>
+                <p>{friendshipLevel}</p>
+                {/* how should I restrict this to a range? Should I make it a number input instead? */}
+                <button id='down' value='down' onClick={(e) => handleClick(id, e, 'down')}><ChevronDown/></button>
+            </section>
+        </>
     )
 }
 

--- a/src/components/Incrementer/Incrementer.tsx
+++ b/src/components/Incrementer/Incrementer.tsx
@@ -36,8 +36,7 @@ function Incrementer({ friendship, id, besties, setBesties }: Props) {
         })
     }
 
-    function handleClick(id: string, e: any/*update to event Type*/, direction: string) {
-        // const direction = e.target.id;
+    function handleClick(id: string, direction: string) {
         updateBestie(id, direction)
     }
 
@@ -45,10 +44,10 @@ function Incrementer({ friendship, id, besties, setBesties }: Props) {
         <>
             <p className='friendship-label'>Friendship Level</p>
             <section className='incrementer'>
-                <button id='up' value='up' onClick={(e) => handleClick(id, e, 'up')}><ChevronUp /></button>
+                <button id='up' value='up' onClick={() => handleClick(id, 'up')}><ChevronUp /></button>
                 <p>{friendshipLevel}</p>
                 {/* how should I restrict this to a range? Should I make it a number input instead? */}
-                <button id='down' value='down' onClick={(e) => handleClick(id, e, 'down')}><ChevronDown/></button>
+                <button id='down' value='down' onClick={() => handleClick(id, 'down')}><ChevronDown/></button>
             </section>
         </>
     )

--- a/src/components/Incrementer/Incrementer.tsx
+++ b/src/components/Incrementer/Incrementer.tsx
@@ -20,6 +20,16 @@ function Incrementer({ friendship, id, besties, setBesties }: Props) {
         } else if (direction === 'down') {
             setFriendshipLevel(friendshipLevel - 1)
         }
+
+        //get and store besties from local storage
+        //clear storage
+        //find and update friendship value of respective friend object
+            //use for each and if the object matches, update friendship property with friendshipLevel
+        //set storage with updated array
+        //get newly stored besties
+        //setBesties with newly stored besties
+
+    
         // const bestie = besties.find(bestie => bestie.id === id)
         // // @ts-expect-error
         // bestie.friendship = friendshipLevel


### PR DESCRIPTION
# Stardew Friends PR

## Summary <!-- what does this PR accomplish? -->
- Develop test suite for user stories and sad paths closes #1 
- Debug and recommission `Incrementer` component closes #15 
- Switch from `session` to `local` storage closes #18 

## Related Issues
- There are still a handful (4?) of `ts-expect-error` declarations in use that I'd like to work on getting rid of

## Screenshots (if applicable) 
![Screenshot 2024-04-17 at 3 37 32 PM](https://github.com/tednaphil/stardew-friends/assets/76406423/9687c774-9bbc-4548-870d-77129a4397db)
![Screenshot 2024-04-17 at 3 38 21 PM](https://github.com/tednaphil/stardew-friends/assets/76406423/26fa247c-c453-4dc5-94c7-63d584a7228c)
![Screenshot 2024-04-17 at 3 39 14 PM](https://github.com/tednaphil/stardew-friends/assets/76406423/24fc63cc-51e2-471f-aa99-99bde59be031)


## Testing
- There appears to be a blinking test failing on line 29 of the `Error.spec.cy.ts` file seemingly sporadically after several concurrent test runs. Could it be too many requests to the API in a short amount of time?
>- tried `cy.wait` and updating stubbed network request for bad path visits to a `200` status 

## Checklist
- [x] Unit and/or acceptance tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [x] The code compiles without errors.
- [x] The changes have been tested locally and pass all relevant tests.
- [x] All new and existing tests pass.
- [x] The pull request has been reviewed by at least one other contributor.

## Additional Information/Next Steps
- Rethink styling for profile details section (please give any input you have) closes #11 
- Update API call response type from `any`
<!--Add one of your buddies as a reviewer-->
